### PR TITLE
Fix profiles, remove TPZ

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog of hydxlib
 1.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Added Heul (HEU), U-Vorm (UVR), Ovaal (OVA) profielen, fixed Muil (MVR),
+  removed trapezium (TPZ).
 
 
 1.1 (2022-11-09)

--- a/hydxlib/tests/test_threedi.py
+++ b/hydxlib/tests/test_threedi.py
@@ -1,11 +1,15 @@
 # -*- coding: utf-8 -*-
 """Tests for threedi.py"""
-from hydxlib.threedi import check_if_element_is_created_with_same_code
-from hydxlib.threedi import get_hydx_default_profile, get_mapping_value, get_cross_section_details
-from hydxlib.threedi import Threedi
 from hydxlib.hydx import Profile
+from hydxlib.threedi import check_if_element_is_created_with_same_code
+from hydxlib.threedi import get_cross_section_details
+from hydxlib.threedi import get_hydx_default_profile
+from hydxlib.threedi import get_mapping_value
+from hydxlib.threedi import Threedi
 from unittest import mock
+
 import pytest
+
 
 MANHOLE_SHAPE_RECTANGLE = "rect"
 MANHOLE_SHAPE_ROUND = "rnd"
@@ -38,9 +42,7 @@ def test_get_mapping_value_right():
 
 
 def test_get_mapping_value_missing(caplog):
-    actual = get_mapping_value(
-        {}, None, "01_TEST", name_for_logging="manhole shape"
-    )
+    actual = get_mapping_value({}, None, "01_TEST", name_for_logging="manhole shape")
     assert not caplog.text
     assert actual is None
 
@@ -210,28 +212,43 @@ def get_profile(**kwargs):
     for (k, v) in kwargs.items():
         setattr(x, k, v)
     return x
-    
 
 
-@pytest.mark.parametrize("vrm,bre,hgt,expected", [
-    ("RND", 500, None, {"shape": 2, "width": 0.5, "height": None}),
-    ("EIV", 1100, None, {"shape": 3, "width": 1.1, "height": None}),
-    ("RHK", 800, 500, {"shape": 0, "width": 0.8, "height": 0.5}),
-])
+@pytest.mark.parametrize(
+    "vrm,bre,hgt,expected",
+    [
+        ("RND", 500, None, {"shape": 2, "width": 0.5, "height": None}),
+        ("EIV", 1100, None, {"shape": 3, "width": 1.1, "height": None}),
+        ("RHK", 800, 500, {"shape": 0, "width": 0.8, "height": 0.5}),
+    ],
+)
 def test_get_cross_section_details(vrm, bre, hgt, expected):
-    profiel = get_profile(vormprofiel=vrm, breedte_diameterprofiel=bre, hoogteprofiel=hgt)
+    profiel = get_profile(
+        vormprofiel=vrm, breedte_diameterprofiel=bre, hoogteprofiel=hgt
+    )
     actual = get_cross_section_details(profiel, None, None)
     assert actual == expected
 
 
-@pytest.mark.parametrize("vrm,expected_shape", [
-    ("TAB", 5),
-    ("HEU", 6),
-    ("MVR", 6),
-    ("UVR", 6),
-    ("OVA", 6),
-])
+@pytest.mark.parametrize(
+    "vrm,expected_shape",
+    [
+        ("TAB", 5),
+        ("HEU", 6),
+        ("MVR", 6),
+        ("UVR", 6),
+        ("OVA", 6),
+    ],
+)
 def test_get_cross_section_details_tabulated(vrm, expected_shape):
-    profiel = get_profile(vormprofiel=vrm, tabulatedbreedte="0.1 0.5 1 1.5", tabulatedhoogte="0 0.25 0.5 1")
+    profiel = get_profile(
+        vormprofiel=vrm,
+        tabulatedbreedte="0.1 0.5 1 1.5",
+        tabulatedhoogte="0 0.25 0.5 1",
+    )
     actual = get_cross_section_details(profiel, None, None)
-    assert actual == {"shape": expected_shape, "width": profiel.tabulatedbreedte, "height": profiel.tabulatedhoogte}
+    assert actual == {
+        "shape": expected_shape,
+        "width": profiel.tabulatedbreedte,
+        "height": profiel.tabulatedhoogte,
+    }

--- a/hydxlib/tests/test_threedi.py
+++ b/hydxlib/tests/test_threedi.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 """Tests for threedi.py"""
 from hydxlib.threedi import check_if_element_is_created_with_same_code
-from hydxlib.threedi import get_hydx_default_profile
+from hydxlib.threedi import get_hydx_default_profile, get_mapping_value, get_cross_section_details
 from hydxlib.threedi import Threedi
+from hydxlib.hydx import Profile
 from unittest import mock
-
+import pytest
 
 MANHOLE_SHAPE_RECTANGLE = "rect"
 MANHOLE_SHAPE_ROUND = "rnd"
@@ -17,8 +18,7 @@ def test_get_mapping_value_wrong(caplog):
     }
     shape_code = "SQR"
     record_code = "01_TEST"
-    threedi = Threedi()
-    threedi.get_mapping_value(
+    get_mapping_value(
         MANHOLE_SHAPE_MAPPING, shape_code, record_code, name_for_logging="manhole shape"
     )
     assert "01_TEST has an unknown manhole shape: SQR" in caplog.text
@@ -31,16 +31,14 @@ def test_get_mapping_value_right():
     }
     shape_code = "RND"
     record_code = "01_TEST"
-    threedi = Threedi()
-    shape = threedi.get_mapping_value(
+    shape = get_mapping_value(
         MANHOLE_SHAPE_MAPPING, shape_code, record_code, name_for_logging="manhole shape"
     )
     assert shape == "rnd"
 
 
 def test_get_mapping_value_missing(caplog):
-    threedi = Threedi()
-    actual = threedi.get_mapping_value(
+    actual = get_mapping_value(
         {}, None, "01_TEST", name_for_logging="manhole shape"
     )
     assert not caplog.text
@@ -205,3 +203,35 @@ def test_import_hydx(hydx):
         "crest_level": 0.0,
         "cross_section_code": "round_0.4",
     }
+
+
+def get_profile(**kwargs):
+    x = Profile()
+    for (k, v) in kwargs.items():
+        setattr(x, k, v)
+    return x
+    
+
+
+@pytest.mark.parametrize("vrm,bre,hgt,expected", [
+    ("RND", 500, None, {"shape": 2, "width": 0.5, "height": None}),
+    ("EIV", 1100, None, {"shape": 3, "width": 1.1, "height": None}),
+    ("RHK", 800, 500, {"shape": 0, "width": 0.8, "height": 0.5}),
+])
+def test_get_cross_section_details(vrm, bre, hgt, expected):
+    profiel = get_profile(vormprofiel=vrm, breedte_diameterprofiel=bre, hoogteprofiel=hgt)
+    actual = get_cross_section_details(profiel, None, None)
+    assert actual == expected
+
+
+@pytest.mark.parametrize("vrm,expected_shape", [
+    ("TAB", 5),
+    ("HEU", 6),
+    ("MVR", 6),
+    ("UVR", 6),
+    ("OVA", 6),
+])
+def test_get_cross_section_details_tabulated(vrm, expected_shape):
+    profiel = get_profile(vormprofiel=vrm, tabulatedbreedte="0.1 0.5 1 1.5", tabulatedhoogte="0 0.25 0.5 1")
+    actual = get_cross_section_details(profiel, None, None)
+    assert actual == {"shape": expected_shape, "width": profiel.tabulatedbreedte, "height": profiel.tabulatedhoogte}

--- a/hydxlib/threedi.py
+++ b/hydxlib/threedi.py
@@ -77,7 +77,6 @@ MANHOLE_INDICATOR_MAPPING = {
     "CMP": ManholeIndicator.MANHOLE.value,
 }
 
-# for now skipping, "HEU"
 SHAPE_MAPPING = {
     "RND": CrossSectionShape.CIRCLE.value,
     "EIV": CrossSectionShape.EGG.value,

--- a/hydxlib/threedi.py
+++ b/hydxlib/threedi.py
@@ -134,14 +134,14 @@ def get_cross_section_details(hydx_profile, record_code, name_for_logging):
     shape = SHAPE_MAPPING.get(hydx_profile.vormprofiel)
     if shape is None:
         logger.error(
-            "%s has an unknown %s: %s", record_code, name_for_logging, hydx_profile.vormprofiel
+            "%s has an unknown %s: %s",
+            record_code,
+            name_for_logging,
+            hydx_profile.vormprofiel,
         )
 
-    return {
-        "shape": shape,
-        "width": breedte_diameterprofiel,
-        "height": hoogteprofiel
-    }
+    return {"shape": shape, "width": breedte_diameterprofiel, "height": hoogteprofiel}
+
 
 class Threedi:
     def __init__(self):
@@ -330,11 +330,10 @@ class Threedi:
             "start_node.code": hydx_connection.identificatieknooppunt1,
             "end_node.code": hydx_connection.identificatieknooppunt2,
             "cross_section_details": get_cross_section_details(
-                    hydx_profile,
-                    record_code=hydx_connection.identificatieprofieldefinitie,
-                    name_for_logging="shape of pipe",
-                )
-            ,
+                hydx_profile,
+                record_code=hydx_connection.identificatieprofieldefinitie,
+                name_for_logging="shape of pipe",
+            ),
             "invert_level_start_point": hydx_connection.bobknooppunt1,
             "invert_level_end_point": hydx_connection.bobknooppunt2,
             "original_length": hydx_connection.lengteverbinding,
@@ -455,10 +454,10 @@ class Threedi:
             "start_node.code": hydx_connection.identificatieknooppunt1,
             "end_node.code": hydx_connection.identificatieknooppunt2,
             "cross_section_details": get_cross_section_details(
-                    hydx_profile,
-                    record_code=hydx_connection.identificatieprofieldefinitie,
-                    name_for_logging="shape of orifice",
-                ),
+                hydx_profile,
+                record_code=hydx_connection.identificatieprofieldefinitie,
+                name_for_logging="shape of orifice",
+            ),
             "discharge_coefficient_positive": hydx_connection.discharge_coefficient_positive,
             "discharge_coefficient_negative": hydx_connection.discharge_coefficient_negative,
             "sewerage": True,


### PR DESCRIPTION
@leendertvanwolfswinkel  The HEU and UVR profiles are simply mapped to tabulated trapezium.

The MVR is precisely the same, but was implemented wrongly, so I fixed that too.

The TPZ is weird: "Bij de profielvorm TPZ gelden bij open leidingen YZ waarden en bij gesloten leidingen tabulated waarden.". This was not done correctly, so I removed it. See email for the question. Do you know if this is crucial for the current project?