### PR TITLE
Added check whether outlet code exists in connection nodes.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog of hydxlib
 1.5.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added check whether outlet code exists in connection nodes.
 
 
 1.5.2 (2024-03-21)

--- a/hydxlib/exporter.py
+++ b/hydxlib/exporter.py
@@ -237,7 +237,11 @@ def write_threedi_to_db(threedi, threedi_db_settings):
     # because of constraints) TO DO: bounds aan meerdere leidingen overslaan
     outlet_list = []
     for outlet in threedi.outlets:
-        outlet["connection_node_id"] = connection_node_dict[outlet["node.code"]]
+        if outlet["node.code"] in connection_node_dict:
+            outlet["connection_node_id"] = connection_node_dict[outlet["node.code"]]
+        else:
+            outlet["connection_node_id"] = None
+            logger.error("Node of outlet not found in connection nodes")
         del outlet["node.code"]
         outlet_list.append(BoundaryCondition1D(**outlet))
 


### PR DESCRIPTION
In case it doesn't exist, it is set to None. 

I don't have that much experience with this library, but this happens in other places as well (such as in get_start_and_end_connection_node). Can you have a look?