### PR TITLE
Skip pumps with identical start and end node

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog of hydxlib
 1.7.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Skip adding pumps when node start and end are identical
 
 
 1.7.0 (2025-03-12)

--- a/hydxlib/exporter.py
+++ b/hydxlib/exporter.py
@@ -173,6 +173,13 @@ def write_threedi_to_db(threedi, threedi_db_settings):
         pump["geom"] = get_node_geom(pump, connection_node_dict, "start_node.code")
         connection_node_id_start = pump.pop("connection_node_id_start")
         connection_node_id_end = pump.pop("connection_node_id_end")
+        if connection_node_id_start is not None and (
+            connection_node_id_start == connection_node_id_end
+        ):
+            logger.error(
+                f"Pump {pump['code']} will be skipped because it has same start and end node"
+            )
+            continue
         del pump["start_node.code"]
         del pump["end_node.code"]
         pump_object = Pump(**pump)

--- a/hydxlib/exporter.py
+++ b/hydxlib/exporter.py
@@ -183,15 +183,29 @@ def write_threedi_to_db(threedi, threedi_db_settings):
         session.refresh(pump_object)
 
         if connection_node_id_start is not None and connection_node_id_end is not None:
-            pump_map_geom = (
-                session.query(func.ST_AsText(func.MakeLine(ConnectionNode.geom)))
-                .filter(
-                    ConnectionNode.id.in_(
-                        [connection_node_id_start, connection_node_id_end]
-                    )
-                )
-                .scalar()
+            start_geom = (
+                session.query(ConnectionNode.geom)
+                .filter(ConnectionNode.id == connection_node_id_start)
+                .scalar_subquery()
             )
+            # When start and end node are the same, the end node must be moved for a valid line
+            if connection_node_id_start != connection_node_id_end:
+                end_geom = (
+                    session.query(ConnectionNode.geom)
+                    .filter(ConnectionNode.id == connection_node_id_end)
+                    .scalar_subquery()
+                )
+            else:
+                end_geom = (
+                    session.query(func.ST_Translate(ConnectionNode.geom, 1, 0, 0))
+                    .filter(ConnectionNode.id == connection_node_id_end)
+                    .scalar_subquery()
+                )
+            pump_map_geom = session.query(
+                func.AsText(func.MakeLine(start_geom, end_geom))
+            ).scalar()
+            if pump_map_geom is None:
+                breakpoint()
             pump_map_list.append(
                 PumpMap(
                     pump_id=pump_object.id,


### PR DESCRIPTION
Pumps with identical start and end connection node are not valid and should thus be skipped (with error).