### PR TITLE
Fix weir cross-section shape and preserve profile width/height for unknown shapes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog of hydxlib
 1.7.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Set weir cross-section shape to closed rectangle; set cross_section_height from OVS_VOH (mm to m) when present (nens/rana#4429).
 
 
 1.7.6 (2026-05-11)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog of hydxlib
 ------------------
 
 - Set weir cross-section shape to closed rectangle; set cross_section_height from OVS_VOH (mm to m) when present (nens/rana#4429).
+- Profiles without a shape now import with shape=NULL and width/height preserved; unknown shape logs a warning (nens/rana#4429).
 
 
 1.7.6 (2026-05-11)

--- a/hydxlib/exporter.py
+++ b/hydxlib/exporter.py
@@ -434,7 +434,7 @@ def get_cross_section_fields(connection, cross_section_dict):
                     connection["cross_section_table"] = "\n".join(
                         [",".join(row) for row in zip(col1, col2)]
                     )
-        elif profile["shape"] is not None:
+        else:
             connection["cross_section_width"] = profile["width"]
             connection["cross_section_height"] = profile["height"]
     else:

--- a/hydxlib/tests/test_threedi.py
+++ b/hydxlib/tests/test_threedi.py
@@ -180,6 +180,18 @@ def test_import_hydx(hydx):
         "sewerage": True,
         "cross_section_code": "weir_ovs83",
     }
+    # weir cross-section: always closed rectangle; height from OVS_VOH (mm -> m)
+    weir_cross_section_ovs83 = next(
+        cs for cs in threedi.cross_sections if cs["code"] == "weir_ovs83"
+    )
+    assert weir_cross_section_ovs83["shape"] == 0  # CLOSED_RECTANGLE
+    assert weir_cross_section_ovs83["height"] == pytest.approx(0.00025)  # 0.25 mm -> m
+
+    weir_cross_section_ovs82 = next(
+        cs for cs in threedi.cross_sections if cs["code"] == "weir_ovs82"
+    )
+    assert weir_cross_section_ovs82["shape"] == 0  # CLOSED_RECTANGLE
+    assert weir_cross_section_ovs82["height"] is None  # no OVS_VOH set
     assert threedi.orifices[1] == {
         "code": "drl97",
         "display_name": "2002-2002-1",

--- a/hydxlib/tests/test_threedi.py
+++ b/hydxlib/tests/test_threedi.py
@@ -214,6 +214,23 @@ def get_profile(**kwargs):
     return x
 
 
+def test_get_cross_section_details_unknown_shape_keeps_width_height(caplog):
+    profiel = get_profile(
+        identificatieprofieldefinitie="PRO",
+        vormprofiel=None,
+        breedte_diameterprofiel="800",
+        hoogteprofiel="500",
+        materiaal="PVC",
+        tabulatedbreedte="",
+        tabulatedhoogte="",
+    )
+    actual = get_cross_section_details(profiel, "PRO", "profile")
+    assert actual["shape"] is None
+    assert actual["width"] == pytest.approx(0.8)
+    assert actual["height"] == pytest.approx(0.5)
+    assert any(r.levelname == "WARNING" for r in caplog.records)
+
+
 @pytest.mark.parametrize(
     "vrm,bre,hgt,expected",
     [

--- a/hydxlib/threedi.py
+++ b/hydxlib/threedi.py
@@ -497,11 +497,12 @@ class Threedi:
             hydx_connection, hydx_structure
         )
 
+        voh = hydx_structure.vrijeoverstorthoogte
         profile = {
             "code": f"weir_{hydx_connection.identificatieknooppuntofverbinding}",
-            "shape": CrossSectionShape.RECTANGLE.value,
+            "shape": CrossSectionShape.CLOSED_RECTANGLE.value,
             "width": hydx_structure.breedteoverstortdrempel,
-            "height": None,
+            "height": float(voh) * 1e-3 if voh else None,
         }
         self.cross_sections.append(profile)
 

--- a/hydxlib/threedi.py
+++ b/hydxlib/threedi.py
@@ -209,20 +209,22 @@ def get_cross_section_details(hydx_profile, record_code, name_for_logging):
     else:
         width = hydx_profile.tabulatedbreedte
         height = hydx_profile.tabulatedhoogte
-        shape = CrossSectionShape.TABULATED_RECTANGLE.value
 
-    if not width:
-        logger.error(
-            "%s has an undefined %s.width: %s",
+    shape = SHAPE_MAPPING.get(hydx_profile.vormprofiel)
+    if shape is None and vormprofiel not in SHAPE_MAPPING:
+        # Unknown/missing shape: fall back to scalar mm fields for width/height
+        width = transform_unit_mm_to_m(hydx_profile.breedte_diameterprofiel)
+        height = transform_unit_mm_to_m(hydx_profile.hoogteprofiel)
+        logger.warning(
+            "%s has an unknown %s: %s",
             record_code,
             name_for_logging,
             hydx_profile.vormprofiel,
         )
 
-    shape = SHAPE_MAPPING.get(hydx_profile.vormprofiel)
-    if shape is None:
+    if not width:
         logger.error(
-            "%s has an unknown %s: %s",
+            "%s has an undefined %s.width: %s",
             record_code,
             name_for_logging,
             hydx_profile.vormprofiel,

--- a/hydxlib/threedi.py
+++ b/hydxlib/threedi.py
@@ -211,7 +211,7 @@ def get_cross_section_details(hydx_profile, record_code, name_for_logging):
         height = hydx_profile.tabulatedhoogte
 
     shape = SHAPE_MAPPING.get(hydx_profile.vormprofiel)
-    if shape is None and vormprofiel not in SHAPE_MAPPING:
+    if shape is None:
         # Unknown/missing shape: fall back to scalar mm fields for width/height
         width = transform_unit_mm_to_m(hydx_profile.breedte_diameterprofiel)
         height = transform_unit_mm_to_m(hydx_profile.hoogteprofiel)


### PR DESCRIPTION
Closes nens/rana#4429

## Changes

### Weir cross-section shape

Previously all weirs were imported with shape `RECTANGLE` (open, value=1) and `cross_section_height=NULL`, ignoring `OVS_VOH` from `Kunstwerk.csv`.

New behaviour:
- Weir cross-section shape is now always `CLOSED_RECTANGLE` (value=0)
- If `OVS_VOH` is set, `cross_section_height` is set to `OVS_VOH * 1e-3` (mm → m)
- If `OVS_VOH` is not set, `cross_section_height` remains `NULL`

### Profiles without a shape

Previously, profiles in `Profiel.csv` with no `PRO_VRM` (shape) set had their width and height silently lost: a logic bug caused the `else` branch to read tabulated fields (always empty for simple profiles), which were then discarded in the exporter because `shape=NULL` was not handled.

New behaviour:
- Profiles with an unknown or missing `PRO_VRM` now fall back to reading `PRO_BRE` and `PRO_HGT` (mm → m), same as named shapes. Note that in case of tabulated data the values are still lost!
- `cross_section_shape` is written as `NULL` in the schematisation
- `cross_section_width` and `cross_section_height` are preserved and written to the output
- A `WARNING` is logged for the unknown shape (previously two `ERROR` entries were logged and data was lost)
- The existing check for undefined width (known shape with no `PRO_BRE`) is retained as an `ERROR`